### PR TITLE
Fixing initialization issue w/ PageHelper

### DIFF
--- a/Web/PageHelper.php
+++ b/Web/PageHelper.php
@@ -58,13 +58,13 @@
 		/**
 		 * Optional string for prefix of page title.
 		 *
-		 * @var null|StringHelper
+		 * @var StringHelper
 		 */
 		protected $titlePrefix = null;
 		/**
 		 * Optional separator for page title and prefix.
 		 *
-		 * @var null|StringHelper
+		 * @var StringHelper
 		 */
 		protected $titleSeparator = null;
 		
@@ -134,7 +134,15 @@
 		 * @param string $name String identifier for page name/root-path.
 		 */
 		protected function __construct(string $name) {
+			$this->get = new ParameterHelper();
 			$this->name = new StringHelper($name);
+			$this->post = new ParameterHelper();
+			$this->request = new ParameterHelper();
+			$this->root = new StringHelper();
+			$this->title = new StringHelper();
+			$this->titlePrefix = new StringHelper();
+			$this->titleSeparator = new StringHelper();
+
 			$this->setRoot(static::getRootPath($name));
 
 			return;


### PR DESCRIPTION
Modified the `PageHelper` class to initialize all of its properties in the constructor, ensuring usage of `StringHelper` methods (among others).

Commit(s):

* [d0ad4d8](https://github.com/zibings/stoic-php-web/commit/d0ad4d86b77e674511ad8a0b1389547255b6500c) [#2] Adding initializers to PageHelper ctor